### PR TITLE
Added section on cultural processing of strings

### DIFF
--- a/_posts/2014-09-19-fsharp-libraries.md
+++ b/_posts/2014-09-19-fsharp-libraries.md
@@ -226,6 +226,136 @@ or a new project, or a component marked Experimental (or similar).
 
 <br />
 
+
+## Guidelines for the cultural processing of strings in .NET generally, and F# specifically 
+
+<br />
+
+### Guideline: Explicitly state cultural intent, where applicable, in the conversion and comparison of strings
+
+Default .NET methods for string conversions of number types and DateTimes (value-to-string; string-to-value) have a notable behaviour characteristic: they are 'culturally sensitive'.  The same applies to the default methods for upper and lower casing of strings (string-to-string conversions).  This means that commonly-used methods such as:-
+
+- Double.ToString()
+- Double.Parse(s)
+- Double.TryParse(s, out d)
+- DateTime.ToString(format) 
+- String.ToUpper() / .ToLower()
+- and many more
+
+use the rules of the *current thread's current culture* to perform their conversions.  Since this culture can vary from machine to machine (and is very likely to do so when machines are located in different countries), use of these method overloads gives rise to many potential problems, including but not limited to:-
+
+- failure to parse a string representing a floating-point number or a date (an exception is thrown)
+- parsing a string that represents a floating-point number or a date to an incorrect value
+- security issues
+- subtle bugs
+
+Similarly, default .NET methods that involve the comparison of strings (for equality testing and ordering) have similar problems.  Methods such as:-
+
+- String.StartsWith(s) / .EndsWith(s)
+- String.IndexOf(s)
+- String.Contains(s)
+- String.Compare(s, s1)
+- String.Equals(s)
+- and more
+
+either use the current thread's current culture for a culturally sensitive comparison, or are fixed to use an Ordinal (non-cultural, case-sensitive) comparison.  The former can give rise to bugs and poor security decisions where the comparison should have been performed non-culturally.  The latter (Ordinal only) may be too restrictive: e.g. the caller may need the comparison to be case-insensitive.    
+
+Since .NET 2.0, released in 2005, all the tools have been in place (in terms of enums, method overloads, .NET types etc.) to allow .NET developers to process strings correctly at all times - especially with respect to performing culturally-varying vs fixed-culture conversions of strings, and cultural vs non-cultural comparisons of strings.  These tools should be used at all times.  To do so, a .NET developer should, in general, always use those method overloads that allow the caller to explicitly state his/her *cultural intent*.
+
+An example, for conversions:-
+
+	open System.Globalization
+	
+	let floatVal = 2001.345
+	
+	let str1 = floatVal.ToString(CultureInfo.InvariantCulture)   // 'string floatVal' does the same thing
+	let str2 = floatVal.ToString(CultureInfo.CurrentCulture)
+	let str3 = floatVal.ToString(new CultureInfo("en-US"))
+
+An example, for comparisons:-
+
+	open System
+	
+	let s1 = "<some string>"
+	let s2 = "<some other string>"
+	
+	let eq1 = String.Equals(s1, s2, StringComparison.Ordinal)   // 's1 = s2' does the same thing
+	let eq2 = String.Equals(s1, s2, StringComparison.OrdinalIgnoreCase)
+
+
+Always explicitly stating cultural intent should ensure correct operation of the code, and - equally as important - shows that the developer is aware of the issues and has addressed them (calling `Double.ToString()`, even when use of the current thread's current culture is desired, gives no such re-assurance).
+
+F# developers should be aware of the behaviour of F#'s [core operators](http://msdn.microsoft.com/en-us/library/ee353754.aspx) with respect to cultural sensitivity:-
+
+- F# and FSharp.Core always use Ordinal (non-cultural, case-sensitive) string comparison by default for "compare", "=", "<>", "<", ">", Seq.sort, Seq.sortBy, HashIdentity.Structural, ComparisonIdentity.Structural and so on
+- core operators `byte`, `decimal`, `float`, `float32`, `int`, `int16`, `int32`, `int64`, `sbyte`, `uint16`, `unit32`, `uint64` convert strings using the invariant culture
+- although core operator `string` is currently documented as "Converts the argument to a string using ToString." - i.e. System.Object.ToString, which would result in a culturally sensitive value-to-string conversion for numbers and DateTimes - in fact it converts numbers and DateTimes using the invariant culture.
+ 
+F# developers can and should rely on the behaviour of these operators, and the need to be explicit about Invariant Culture conversions and Ordinal comparisons is removed when using these operators.    
+
+
+<br />
+
+### Guideline: Always follow the long-established Best Practices for using strings in the .NET Framework
+
+See Microsoft's official [Best Practices for Using Strings in the .NET Framework](http://msdn.microsoft.com/en-us/library/dd465121%28v=vs.110%29.aspx), as well as the specific guidance for F# developers that is given in this document.
+
+
+<br />
+
+### Guideline: F# components should be tested to ensure that they behave correctly when operating under different cultures 
+
+Unit tests typically run in-process and on the same thread as the code-under-test.  Therefore culture testing may be as simple as modifying the current thread's current culture in the Act (or Setup) phase of the test; e.g.
+
+	// change the current thread's current culture to French - France 
+	System.Threading.Thread.CurrentThread.CurrentCulture <- CultureInfo.CreateSpecificCulture("fr-FR")
+
+Integration tests may need to go to greater lengths to manipulate the code-under-test's culture, including modification of the test machine's Region and Language control panel settings. 
+
+
+<br />
+
+### Guideline: Public-facing F# libraries should make sensible decisions about cultural string processing, and should strive for consistency
+
+A public-facing library that might reasonably be expected to run on machines of different cultures should ensure that all of the code is written to process strings correctly, with respect to cultural / non-cultural behaviour.  Contributors should be encouraged to follow rules and guidelines that are established at the outset, so that the code is consistent in this regard.
+
+If library-specific functions are used to wrap .NET string conversion and comparison methods then:-
+
+- these functions should be used by all contributors 
+- the functions should encourage callers to be explicit about cultural intent, and not hide such details
+- the functions should wrap only those .NET method overloads that allow callers to be explicit about cultural intent
+
+If library-specific operators are used to wrap .NET string conversion and comparison methods then their cultural operation should be explicitly documented and understood by all contributors.
+
+On the whole it's best to err on the side of caution and *not* introduce such library-specific functions and operators, since contributors may contribute to multiple libraries.  
+
+Where libraries introduce new data structures + associated operators and functions that use string-based identifiers (e.g. keys), the default string comparison for these identifiers should be Ordinal (non-cultural, case-sensitive).  This should be noted in a library's documentation.
+
+
+<br />
+
+### Guideline: Use FxCop / Code Analysis to find string processing problems wrt culture
+
+Pass all assemblies through FxCop / Code Analysis and fix violations of the following rules:-
+
+- [CA1304: Specify CultureInfo](http://msdn.microsoft.com/en-us/library/ms182189.aspx)
+- [CA1305: Specify IFormatProvider](http://msdn.microsoft.com/en-us/library/ms182190.aspx)
+- [CA1307: Specify StringComparison](http://msdn.microsoft.com/en-us/library/bb386080.aspx)
+- [CA1308: Normalize strings to uppercase]([http://msdn.microsoft.com/en-us/library/bb386042.aspx)
+- [CA1309: Use ordinal StringComparison](http://msdn.microsoft.com/en-us/library/bb385972.aspx)
+ 
+
+<br />
+
+### Guideline: Avoid .NET 2.0 documentation pages on the web
+
+If a web search causes you to land on a Microsoft .NET documentation page whose version is ".NET Framework 2.0", switch versions to the version you are using (e.g. .NET Framework 4; .NET Framework 4.5).  It is known that methods such as String.Replace were incorrectly documented from .NET 1.0 to 2.0, with respect to their cultural operation.
+
+For .NET 2.0, the documentation for String.Replace says "This method performs a word (case-sensitive and culture-sensitive) search to find oldValue.".  For all later versions of .NET the documentation says "This method performs an ordinal (case-sensitive and culture-insensitive) search to find oldValue.".  The latter statement is correct.  String.Replace always did use an ordinal search from the outset; its documentation was incorrect from 2002 to 2005.
+
+
+<br />
+
 ## General Guidelines
 
 <br />


### PR DESCRIPTION
Added section "Guidelines for the cultural processing of strings in .NET generally, and F# specifically" just before the "General Guidelines" section.
