### PR TITLE
Update layout to provide proper name for F# Software Foundation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,7 +33,7 @@
                     <li><a href="/#bloglist">Blog</a></li>
                     <li><a href="https://github.com/fsharp">Core Projects</a></li>
                     <li><a href="https://github.com/fsprojects">Incubation Zone</a></li>
-                    <li><a href="http://fsharp.org">F# Foundation</a></li>
+                    <li><a href="http://fsharp.org">F# Software Foundation</a></li>
                     <li><a href="/#contact-us">Contact</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
Changed link from "F# Foundation" to "F# Software Foundation"
