### PR TITLE
Fixed 2 typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ facilitate open-source contributions to the F# core components. For example:
 Maintainers
 -----------
 
-Tha maintainers of this repository appointed by the F# Core Engineering Group are:
+The maintainers of this repository appointed by the F# Core Engineering Group are:
 
  - [Dave Thomas](https://github.com/7sharp9), [Tomas Petricek](http://github.com/tpetricek) 
  - with help and guidance from [Don Syme](http://github.com/dsyme), 

--- a/_posts/2014-09-19-fsharp-libraries.md
+++ b/_posts/2014-09-19-fsharp-libraries.md
@@ -340,7 +340,7 @@ Pass all assemblies through FxCop / Code Analysis and fix violations of the foll
 - [CA1304: Specify CultureInfo](http://msdn.microsoft.com/en-us/library/ms182189.aspx)
 - [CA1305: Specify IFormatProvider](http://msdn.microsoft.com/en-us/library/ms182190.aspx)
 - [CA1307: Specify StringComparison](http://msdn.microsoft.com/en-us/library/bb386080.aspx)
-- [CA1308: Normalize strings to uppercase]([http://msdn.microsoft.com/en-us/library/bb386042.aspx)
+- [CA1308: Normalize strings to uppercase](http://msdn.microsoft.com/en-us/library/bb386042.aspx)
 - [CA1309: Use ordinal StringComparison](http://msdn.microsoft.com/en-us/library/bb385972.aspx)
  
 


### PR DESCRIPTION
"Tha" -> "The" in README.md.
Corrected Markdown-format URL to MSDN help page in 2014-09-19-fsharp-libraries.md.