### PR TITLE
clarify versions to use for netstandard libraries

### DIFF
--- a/_posts/2015-04-18-fsharp-core-notes.md
+++ b/_posts/2015-04-18-fsharp-core-notes.md
@@ -87,7 +87,8 @@ and the _earliest_ and _most supported_ profiles of the .NET Framework feasible.
 
 As of February 2018 new editions of F# libraries should generally do the following:
 * Be `netstandard1.6`, or `netstandard2.0` with an additional .NET Framework 4.5 (`net45`) build
-* Use FSharp.Core nuget 4.2.3 (assembly version 4.4.1.0) or 4.3.3 (assembly version 4.4.3.0)
+* Use FSharp.Core nuget 4.2.3 (assembly version 4.4.1.0) for `netstandard1.6`
+* Use FSharp.Core nuget 4.3.3 (assembly version 4.4.3.0) for `netstandard2.0`
 
 You should no longer make your library a PCL "Portable" component. They are deprecated.
 


### PR DESCRIPTION
This is to update Notes and Guidance on FSharp.Core https://fsharp.github.io/2015/04/18/fsharp-core-notes.html

Is this change correct? It looks to me like the nuget packages 4.3.x are the first to support netstandard2.0 and 4.2x are the first to support netstandard1.6. Should libraries target the highest or lowest third digit? For example, for a library targeting netstandard2.0, should it target FSharp.Core nupkg or 4.3.1 or 4.3.4?

![image](https://user-images.githubusercontent.com/80104/46389544-0d950a00-c698-11e8-8f30-d68d4eff4b5b.png)

Trying to figure out what https://github.com/xyncro/chiron/pull/100 should be set to. cc @ninjarobot